### PR TITLE
記事詳細画面の追加

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,2 +1,23 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
+.prose {
+  line-height: 1.9;
+  font-size: 1.02rem;
+  word-break: break-word;
+}
+
+.tags { gap: .5rem; flex-wrap: wrap; }
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: .35rem .6rem;
+  font-size: .85rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(0,0,0,.06);
+  background: rgb(134, 201, 238);         /* ←ご希望の薄いグレー */
+  color: #0a0d0c;
+  user-select: none;
+  letter-spacing: .02em;
+  box-shadow: 0 1px 1px rgba(0,0,0,.03);
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,11 +1,15 @@
 class ArticlesController < ApplicationController
   # before_action :require_login, only: %i[new create]
+  before_action :set_article, only: [:show]
 
   def index
     @articles = Article
       .includes(:user)
       .with_attached_image
       .order(created_at: :desc)
+  end
+
+  def show
   end
 
   def new
@@ -33,6 +37,10 @@ class ArticlesController < ApplicationController
   end
 
   private
+
+  def set_article
+    @article = Article.find(params[:id])
+  end
 
   def article_params
     # ★ guest_name を許可する（guest_email を使わないなら不要）

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,2 +1,9 @@
 module ArticlesHelper
+    def display_author(article)
+      article.user&.name || article.guest_name || "ゲスト"
+    end
+
+    def kind_label(article)
+      article.shop? ? "店舗情報" : "商品情報"
+    end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -7,6 +7,8 @@ class Article < ApplicationRecord
   # 後で acts-as-taggable-on 等を入れるまでの“受け口”
   attr_accessor :tag_names
 
+  before_validation :copy_tag_names_to_tags_text
+
   validates :title, presence: true, length: { maximum: 120 }
   validates :body,  presence: true
 
@@ -21,6 +23,10 @@ class Article < ApplicationRecord
   end
 
   private
+
+  def copy_tag_names_to_tags_text
+    self.tags_text = tag_names if tag_names.present?
+  end
 
   def author_presence
     if user.nil? && guest_name.blank?

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -10,18 +10,25 @@
           <% @articles.each do |article| %>
             <div class="col-12 col-md-6 col-lg-4">
               <div class="card h-100 shadow-sm">
-                <% if article.image.attached? %>
-                  <%= image_tag article.image, class: "card-img-top",
-                        style: "height: 220px; object-fit: cover;" %>
-                <% else %>
-                  <div class="bg-light" style="height: 220px;"></div>
+                <%= link_to article_path(article), class: "d-block text-decoration-none" do %>
+                  <% if article.image.attached? %>
+                    <%= image_tag article.image,
+                          class: "card-img-top",
+                          style: "height: 220px; object-fit: cover;",
+                          alt: article.title %>
+                  <% else %>
+                    <div class="bg-light d-flex align-items-center justify-content-center"
+                         style="height: 220px;">
+                      <span class="text-muted">画像なし</span>
+                    </div>
+                  <% end %>
                 <% end %>
 
                 <div class="card-body">
                   <div class="d-flex justify-content-between align-items-center">
                     <div class="small text-muted">
                       <i class="bi bi-person"></i>
-                      <%= article.user.name %>
+                      <%= article.user&.name || article.guest_name || "ゲスト" %>
                     </div>
                     <div class="small">
                       <i class="bi bi-hand-thumbs-up"></i>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,0 +1,114 @@
+<div class="container-fluid">
+  <div class="row">
+    <%= render "shared/sidebar" %>
+
+    <main class="col py-4">
+      <div class="d-flex justify-content-end mb-3">
+        <%= link_to "← 記事一覧に戻る", articles_path, class: "btn btn-sm btn-outline-secondary" %>
+      </div>
+
+      <div class="row g-4">
+        <!-- 左：画像 + 指標（いいね/コメント） -->
+        <div class="col-12 col-lg-5 d-flex flex-column align-items-start">
+          <div
+            class="rounded shadow-sm border overflow-hidden mx-auto mx-lg-0"
+            style="--img-size: 320px; width: min(100%, var(--img-size)); aspect-ratio: 1 / 1;"
+          >
+            <% if @article.image.attached? %>
+              <%= image_tag @article.image,
+                    class: "w-100 h-100",
+                    style: "object-fit: cover;",
+                    alt: @article.title %>
+            <% else %>
+              <div class="w-100 h-100 bg-light d-flex align-items-center justify-content-center">
+                <i class="bi bi-image text-muted fs-1"></i>
+              </div>
+            <% end %>
+          </div>
+
+          <!-- 画像の下：いいね数 / コメント数 -->
+          <div class="d-flex align-items-center gap-3 mt-2 small text-muted">
+            <span>
+              <i class="bi bi-hand-thumbs-up"></i>
+              <%= @article.respond_to?(:likes_count) ? @article.likes_count.to_i : 0 %>
+            </span>
+            <span>
+              <i class="bi bi-chat-left-text"></i>
+              <%= @article.respond_to?(:comments) ? @article.comments.size : 0 %>
+            </span>
+          </div>
+        </div>
+
+        <!-- 右：プロフィール + タイトル + 投稿者名 + 本文 + タグ + 追加情報 -->
+        <div class="col-12 col-lg-6">
+          <!-- プロフィール画像の横にタイトル -->
+          <div class="d-flex align-items-start gap-3">
+            <!-- 仮アバター（後でユーザーアイコンに差し替え） -->
+            <div class="flex-shrink-0">
+              <div class="rounded-circle bg-secondary-subtle d-flex align-items-center justify-content-center border"
+                   style="width:56px; height:56px;">
+                <i class="bi bi-person text-secondary fs-3"></i>
+              </div>
+            </div>
+
+            <div class="flex-grow-1">
+              <h1 class="h5 mb-1"><%= @article.title %></h1>
+              <div class="text-muted small">
+                投稿者：<%= @article.user&.name || @article.guest_name || "ゲスト" %>
+              </div>
+
+              <% if @article.kind.present? %>
+                <div class="mt-2">
+                  <span class="badge text-bg-light border">
+                    <%= @article.shop? ? "店舗" : "商品" %>
+                  </span>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <!-- 本文 -->
+          <div class="mt-3">
+            <h2 class="h6 text-muted">本文</h2>
+            <div><%= simple_format(@article.body) %></div>
+          </div>
+
+          <!-- タグ -->
+          <% tags_text = @article.try(:tags_text).presence || @article.try(:tag_names).presence %>
+          <% if tags_text.present? %>
+            <div class="mt-3">
+              <div class="d-flex flex-wrap gap-2">
+                <% tags_text.split(/[、,\s]+/).reject(&:blank?).each do |tag| %>
+                  <span class="badge rounded-pill tag-chip"><%= tag %></span>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+
+          <!-- 追加情報（店舗/商品で見出しを切替） -->
+          <% if @article.extra_info.present? %>
+            <div class="mt-3">
+              <h2 class="h6 text-muted"><%= @article.shop? ? "店舗情報" : "商品情報" %></h2>
+              <div><%= simple_format(@article.extra_info) %></div>
+            </div>
+          <% end %>
+
+      <%# 下：編集／削除（本人のみ） %>
+      <% if current_user&.id == @article.user_id %>
+        <div class="d-flex justify-content-start gap-2 mt-4 border-top pt-3">
+          <%= link_to edit_article_path(@article), class: "btn btn-sm btn-outline-primary" do %>
+            <i class="bi bi-pencil"></i> 編集
+          <% end %>
+
+          <%= button_to article_path(@article),
+                method: :delete,
+                form: { class: "d-inline" },
+                data: { turbo_confirm: "本当に削除しますか？" },
+                class: "btn btn-sm btn-outline-danger" do %>
+            <i class="bi bi-trash"></i> 削除
+          <% end %>
+        </div>
+      <% end %>
+    </main>
+  </div>
+</div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -8,7 +8,7 @@
       <%= link_to "プロフィール", "#", class: "nav-link text-body disabled" %>
     <% end %>
 
-    <%= link_to "カテゴリー別", categories_path, class: "nav-link text-body" %>
+    <%= link_to "カテゴリー別", "#", class: "nav-link text-body" %>
     <%= link_to "検索", "#", class: "nav-link text-body disabled" %>
   </nav>
 </aside>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  get "sessions/new"
-  get "users/new"
-  get "users/create"
   root "home#index"
 
   # 後で使うルーティング（今は動かなくてもOK）

--- a/db/migrate/20250815050519_add_tags_text_to_articles.rb
+++ b/db/migrate/20250815050519_add_tags_text_to_articles.rb
@@ -1,0 +1,5 @@
+class AddTagsTextToArticles < ActiveRecord::Migration[8.0]
+  def change
+    add_column :articles, :tags_text, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_14_140620) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_15_050519) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_14_140620) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "guest_name"
+    t.text "tags_text"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -22,6 +22,13 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
         }
       }
     end
+
+    test "should show article" do
+      article = articles(:one)
+      get article_url(article)
+      assert_response :success
+    end
+
     assert_redirected_to articles_url
   end
 end


### PR DESCRIPTION
# 概要
記事詳細画面の追加

## 内容
- [ ] コントローラーへの追加
- [ ] 一覧画像のリンク化
- [ ] ビューの作成
- [ ] 編集ボタンと削除ボタンの追加（機能は未実装）
- [ ] 投稿画面のタグを詳細画面へ反映
